### PR TITLE
Remove console.dir()

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,6 @@ Client.prototype.getTransport = function(cb) {
 	var me = this;
 	
 	function doCb(error, transport) {
-		console.dir(me.getTransportRequests);
 		while (me.getTransportRequests.length > 0) {
 			var nextCb = me.getTransportRequests.shift();
 			nextCb(error, transport);


### PR DESCRIPTION
Was wondering where all the "[ [Function] ]" in my logs were originating from, and it was this line.

Logging is fine, but it shouldn't be enabled by default except to spit out errors.
