### PR TITLE
Add convenience methods per log level

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,35 +181,36 @@ Client.prototype.log = function(message, options, cb) {
 /**
  * Convenience methods to send messages of a given severity
 */
-Client.prototype.notice = function(message, cb) {
-	var self = this;
+Client.prototype.notice = function(message) {
 	options = { "severity": Severity.Notice };
-	this.log(message, options, cb);
+	this.log(message, options, this.loggerCallback);
 };
 
-Client.prototype.info = function(message, cb) {
-	var self = this;
+Client.prototype.info = function(message) {
 	options = { "severity": Severity.Informational };
-	this.log(message, options, cb);
+	this.log(message, options, this.loggerCallback);
 };
 
-Client.prototype.warn = function(message, cb) {
-	var self = this;
+Client.prototype.warn = function(message) {
 	options = { "severity": Severity.Warn };
-	this.log(message, options, cb);
+	this.log(message, options, this.loggerCallback);
 };
 
-Client.prototype.error = function(message, cb) {
-	var self = this;
+Client.prototype.error = function(message) {
 	options = { "severity": Severity.Error };
-	this.log(message, options, cb);
+	this.log(message, options, this.loggerCallback);
 };
 
-Client.prototype.debug = function(message, cb) {
-	var self = this;
+Client.prototype.debug = function(message) {
 	options.severity = Severity.Debug;
-	this.log(message, options, cb);
+	this.log(message, options, this.loggerCallback);
 };
+
+Client.prototype.loggerCallback = function(err) {
+	if(err) {
+		console.log(err);
+	}
+}
 
 Client.prototype.getTransport = function(cb) {
 	this.getTransportRequests.push(cb);

--- a/index.js
+++ b/index.js
@@ -181,34 +181,34 @@ Client.prototype.log = function(message, options, cb) {
 /**
  * Convenience methods to send messages of a given severity
 */
-Client.prototype.notice = function(message, options, cb) {
-  var self = this;
-  options.severity = Severity.Notice;
-  this.log(message, options, cb);
+Client.prototype.notice = function(message, cb) {
+	var self = this;
+	options = { "severity": Severity.Notice };
+	this.log(message, options, cb);
 };
 
-Client.prototype.info = function(message, options, cb) {
-  var self = this;
-  options.severity = Severity.Informational;
-  this.log(message, options, cb);
+Client.prototype.info = function(message, cb) {
+	var self = this;
+	options = { "severity": Severity.Informational };
+	this.log(message, options, cb);
 };
 
-Client.prototype.warn = function(message, options, cb) {
-  var self = this;
-  options.severity = Severity.Warn;
-  this.log(message, options, cb);
+Client.prototype.warn = function(message, cb) {
+	var self = this;
+	options = { "severity": Severity.Warn };
+	this.log(message, options, cb);
 };
 
-Client.prototype.error = function(message, options, cb) {
-  var self = this;
-  options.severity = Severity.Error;
-  this.log(message, options, cb);
+Client.prototype.error = function(message, cb) {
+	var self = this;
+	options = { "severity": Severity.Error };
+	this.log(message, options, cb);
 };
 
-Client.prototype.debug = function(message, options, cb) {
-  var self = this;
-  options.severity = Severity.Debug;
-  this.log(message, options, cb);
+Client.prototype.debug = function(message, cb) {
+	var self = this;
+	options.severity = Severity.Debug;
+	this.log(message, options, cb);
 };
 
 Client.prototype.getTransport = function(cb) {

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ Client.prototype.error = function(message) {
 };
 
 Client.prototype.debug = function(message) {
-	options.severity = Severity.Debug;
+	options = { "severity": Severity.Debug };
 	this.log(message, options, this.loggerCallback);
 };
 

--- a/index.js
+++ b/index.js
@@ -178,6 +178,38 @@ Client.prototype.log = function(message, options, cb) {
 	
 	return this;
 };
+/**
+ * Convenience methods to send messages of a given severity
+*/
+Client.prototype.notice = function(message, options, cb) {
+  var self = this;
+  options.severity = Severity.Notice;
+  this.log(message, options, cb);
+};
+
+Client.prototype.info = function(message, options, cb) {
+  var self = this;
+  options.severity = Severity.Informational;
+  this.log(message, options, cb);
+};
+
+Client.prototype.warn = function(message, options, cb) {
+  var self = this;
+  options.severity = Severity.Warn;
+  this.log(message, options, cb);
+};
+
+Client.prototype.error = function(message, options, cb) {
+  var self = this;
+  options.severity = Severity.Error;
+  this.log(message, options, cb);
+};
+
+Client.prototype.debug = function(message, options, cb) {
+  var self = this;
+  options.severity = Severity.Debug;
+  this.log(message, options, cb);
+};
 
 Client.prototype.getTransport = function(cb) {
 	this.getTransportRequests.push(cb);


### PR DESCRIPTION
Hey Stephen,

Really like the project - happily using it in an app I'm working on and enjoying the results of your work.  There was one thing I felt was missing that I implemented for my purposes, so I'm creating this PR to see if you are interested in accepting it back into the main repo.

Many logging systems provide convenience methods per log-level.  This means instead of having to create an options object, and then call the logger, a developer can just do something like this:
`logger.debug("This is a debug level statement");`

Since logging happens so much through a piece of software, making it an easy one-liner to type is a key feature.

Thanks,

Dan
