### PR TITLE
Back-dated timestamps and RFC 5424

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ The optional `target` parameter defaults to `127.0.0.1`.  The optional
  * `transport` - Specify the transport to use, can be either
    `syslog.Transport.Udp` or `syslog.Transport.Tcp`, defaults to
    `syslog.Transport.Udp`
+ * `facility` - set default for `client.log()`; default is `syslog.Facility.Local0`.
+ * `severity` - set default for `client.log()`; default is `syslog.Severity.Informational`.
+ * `rfc3164` - set to false to use [RFC 5424](https://tools.ietf.org/html/rfc5424)
+   syslog header format; default is true for the older [RFC 3164](https://tools.ietf.org/html/rfc3164)
+   format.
 
 ## client.on("close", callback)
 
@@ -171,10 +176,15 @@ items:
 
  * `facility` - Either one of the constants defined in the `syslog.Facility`
    object or the facility number to use for the message, defaults to
-   `syslog.Facility.Local0`
+   `syslog.Facility.Local0` (see `syslog.createClient()`)
  * `severity` - Either one of the constants defined in the `syslog.Severity`
    object or the severity number to use for the message, defaults to
-   `syslog.Severity.Informational`
+   `syslog.Severity.Informational` (see `syslog.createClient()`)
+ * `rfc3164` - set to false to use [RFC 5424](https://tools.ietf.org/html/rfc5424)
+   syslog header format; default is true for the older [RFC 3164](https://tools.ietf.org/html/rfc3164)
+   format.
+ * `timestamp` - Optional Javascript Date() object to back-date the message.
+ * `msgid` - Optional [RFC 5424](https://tools.ietf.org/html/rfc5424) message-id.
 
 The `callback` function is called once the message has been sent to the remote
 host, or an error occurred.  The following arguments will be passed to the

--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ function Client(target, options) {
 	this.getTransportRequests = [];
 	this.facility = options.facility || Facility.Local0;
 	this.severity =	options.severity || Severity.Informational;
+	this.rfc3164 = options.rfc3164 || true;
 	
 	this.transport = Transport.Udp;
 	if (options.transport &&
@@ -178,6 +179,9 @@ Client.prototype.log = function log() {
 	}
 	if (typeof options.severity === "undefined") {
 		options.severity = this.severity;
+	}
+	if (typeof options.rfc3164 === "undefined") {
+		options.rfc3164 = this.rfc3164;
 	}
 
 	var fm = this.buildFormattedMessage(message, options);

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ Client.prototype.buildFormattedMessage = function buildFormattedMessage(message,
 
 		formattedMessage = "<"
 				+ pri
-				+ "> "
+				+ ">"
 				+ timestamp
 				+ " "
 				+ this.syslogHostname

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ Client.prototype.buildFormattedMessage = function buildFormattedMessage(message,
 
 		formattedMessage = "<"
 				+ pri
-				+ "> "
+				+ ">1 "				// VERSION 1
 				+ date.toISOString()
 				+ " "
 				+ this.syslogHostname

--- a/test/syslog-client.js
+++ b/test/syslog-client.js
@@ -59,7 +59,7 @@ function constructSyslogRegex(pri, hostname, msg, timestamp) {
 	return new RegExp(
 		"^<"+
 		escapeRegExp(pri)+
-		"> "+
+		">"+
 		pat_date+
 		" "+
 		escapeRegExp(hostname)+

--- a/test/syslog-client.js
+++ b/test/syslog-client.js
@@ -76,7 +76,7 @@ function constructRfc5424Regex(pri, hostname, msg, msgid, timestamp) {
 	return new RegExp(
 		"^<"+
 		escapeRegExp(pri)+
-		"> "+
+		">\\d+ "+
 		pat_date+
 		" "+
 		escapeRegExp(hostname)+
@@ -604,12 +604,12 @@ describe("Syslog Client", function () {
 		.then(function (msg) {
 			assert.match(msg, constructRfc5424Regex(134, hostname, "This is a test", 98765, backdate));
 			client.log("This is a second test", {
-				rfc3164: false, msgid: 102938
+				rfc3164: false
 			});
 			return awaitSyslogUdpMsg();
 		})
 		.then(function (msg) {
-			assert.match(msg, constructRfc5424Regex(134, hostname, "This is a second test", 102938));
+			assert.match(msg, constructRfc5424Regex(134, hostname, "This is a second test", "-"));
 		});
 	});
 });


### PR DESCRIPTION
I've added optional support RFC 5424 syslog header format and the ability to specify the time stamp to client.log() if necessary.  We had a need for this in a special logging application:

	// Some applications, like LTE CDR collection, need to be able to
	// back-date log messages based on CDR timestamps across different
	// time zones, because of delayed record collection with 3rd parties.
	// Particular useful in when feeding CDRs to Splunk for indexing.

I've added two tests to test back-dating and the newer RFC 5424 syslog header format.
