### PR TITLE
Make ClientOptions.udpBindAddress optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ export interface ClientOptions {
 	transport?: Transport,
 	timestamp?: Date,
 	msgid?: string,
-	udpBindAddress: string
+	udpBindAddress?: string
 }
 
 export interface MessageOptions {


### PR DESCRIPTION
The type definitions define `ClientOptions.udpBindAddress` as mandatory, which breaks compatibility to 1.1.1 and requires to define a value even when it is not used.
This commit fixes this by declaring `udpBindAddress` to be optional.